### PR TITLE
Updated BungeeCord API Dependancy in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>net.md-5</groupId>
             <artifactId>bungeecord-api</artifactId>
-            <version>1.7-SNAPSHOT</version>
+            <version>1.8-SNAPSHOT</version>
             <type>jar</type>
             <scope>provided</scope>
         </dependency>


### PR DESCRIPTION
As title says - dependancy listed doesn't contain ProxiedPlayer getModList() method.

Thanks
